### PR TITLE
Remove hardcoded player name from Main menu

### DIFF
--- a/Assets/SceneBuilding/Scenes/GameScenes/Menus/Main menu.unity
+++ b/Assets/SceneBuilding/Scenes/GameScenes/Menus/Main menu.unity
@@ -224,10 +224,6 @@ PrefabInstance:
       propertyPath: m_Name
       value: Main Menu
       objectReference: {fileID: 0}
-    - target: {fileID: 1139948687001568094, guid: fb539bc52f0954f2298679b40574e819, type: 3}
-      propertyPath: m_Name
-      value: Jayden McCain
-      objectReference: {fileID: 0}
     - target: {fileID: 4029218821887963838, guid: fb539bc52f0954f2298679b40574e819, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
@@ -267,10 +263,6 @@ PrefabInstance:
     - target: {fileID: 4029218821887963838, guid: fb539bc52f0954f2298679b40574e819, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5359357361381889907, guid: fb539bc52f0954f2298679b40574e819, type: 3}
-      propertyPath: m_text
-      value: Jayden McCain
       objectReference: {fileID: 0}
     - target: {fileID: 7887774721920853735, guid: fb539bc52f0954f2298679b40574e819, type: 3}
       propertyPath: m_Events.m_Events.Array.data[2].m_PersistentCalls.m_Calls.Array.data[0].m_Target


### PR DESCRIPTION
Delete serialized references to the hardcoded name "Jayden McCain" from the Main menu prefab instance in Assets/SceneBuilding/Scenes/GameScenes/Menus/Main menu.unity. This cleans up m_Name and m_text entries that embedded a specific user name in the scene file, leaving the prefab instance without the hardcoded username (no functional behavior changes intended).